### PR TITLE
Fix geojson file loading in examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@ title: Turf.js
 var turf = require('turf');
 var fs = require('fs');
 
-var wombats = fs.readFileSync('./wombats.geojson');
-var snakes = fs.readFileSync('./snakes.geojson');
+var wombats = JSON.parse(fs.readFileSync('./wombats.geojson'));
+var snakes = JSON.parse(fs.readFileSync('./snakes.geojson'));
 
 var oneMileRing = turf.buffer(wombats, 1, 'miles');
 var snakesNearWombats = turf.within(snakes, oneMileRing);


### PR DESCRIPTION
I'm new to node.js (I just started earlier today) and I was trying out the examples. I kept getting the following error

```shell
Error: Unknown GeoJSON type: undefined
    at jsts.io.GeoJSONParser.read (C:\Users\geonin\node_modules\turf\node_modules\turf-intersect\node_modules\jsts\lib\jsts.js:1013:47)
    at jsts.io.GeoJSONReader.read (C:\Users\geonin\node_modules\turf\node_modules\turf-intersect\node_modules\jsts\lib\jsts.js:97:351)
    at Object.module.exports [as intersect] (C:\Users\geonin\node_modules\turf\node_modules\turf-intersect\index.js:20:16)
    at Object.<anonymous> (C:\Users\geonin\code\noderight\turf-intersectup.js:26:29)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
```

Console.log shows that that the values of the loaded geojson files are buffers and hence aren't valid geojson objects

```shell
<Buffer 7b 0d 0a 20 20 22 74 79 70 65 22 3a 20 22 50 6f 6c 79 67 6f 6e 22 2c 0d 0a 20 20 22 63 6f 6f 72 64 69 6e 61 74 65 73 22 3a 20 5b 0d 0a 20 20 20 20 5b 0d ...>
<Buffer 7b 0d 0a 20 20 22 74 79 70 65 22 3a 20 22 50 6f 6c 79 67 6f 6e 22 2c 0d 0a 20 20 22 63 6f 6f 72 64 69 6e 61 74 65 73 22 3a 20 5b 0d 0a 20 20 20 20 5b 0d ...>
```

Added the encoding option for fs.readFileSync as stated in the fs API and the files are finally recognized as geojson but I still kept getting the same error. Finally got it to work by using JSON.parse(). (Should I have filed this as a bug report first?)





