### PR TITLE
fix API doc link in example pages

### DIFF
--- a/turf-jsdoc/tmpl/layout.tmpl
+++ b/turf-jsdoc/tmpl/layout.tmpl
@@ -27,7 +27,7 @@
         </a>
       <div class='inline pad2y'>
         <div class='tabs'>
-          <a href='/docs/' class='active'>API Docs</a><a
+          <a href='/static/docs/' class='active'>API Docs</a><a
             href='https://github.com/Turfjs/turf' class='icon github' target="_blank">Source</a>
         </div>
       </div>


### PR DESCRIPTION
The API docs link in the example pages points to: http://turfjs.org/docs/ but that doesn't exist.