### PR TITLE
Update Turf and Mapbox.js versions on website

### DIFF
--- a/_posts/index.html
+++ b/_posts/index.html
@@ -60,7 +60,7 @@ and node</p>
         <h3>CDN</h3>
       </div>
       <div class='col10 scroll-styled'>
-        <pre>//api.tiles.mapbox.com/mapbox.js/plugins/turf/v1.4.0/turf.min.js</pre>
+        <pre>//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js</pre>
       </div>
     </div>
   </div>

--- a/templates/prose.html
+++ b/templates/prose.html
@@ -4,9 +4,9 @@
   <title><%= title %></title>
   <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
   <link href='/assets/css/main.css' rel='stylesheet' />
-  <script src='//api.tiles.mapbox.com/mapbox.js/plugins/turf/v1.3.0/turf.min.js'></script>
-  <script src='https://api.tiles.mapbox.com/mapbox.js/v2.1.4/mapbox.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox.js/v2.1.4/mapbox.css' rel='stylesheet' />
+  <script src='//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js'></script>
+  <script src='https://api.tiles.mapbox.com/mapbox.js/v2.1.6/mapbox.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox.js/v2.1.6/mapbox.css' rel='stylesheet' />
 </head>
 <body>
 <div class='unlimiter fill-turf-green clearfix'>


### PR DESCRIPTION
- updates `prose.html` template to include latest versions of Turf and Mapbox.js
- updates CDN URL in `_posts/index.html` to latest version of Turf

These are live on the site on the `gh-pages` branch but want to merge into `master` as well for future doc pulls and updates.