### PR TITLE
Automated Testing of JSDoc @examples - WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 # ignore jekyll build artifacts
 _site
 _docs
+
+# ignore generated test file
+test/turf.js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "turf"]
 	path = turf
-	url = https://github.com/Turfjs/turf.git
+	url = https://github.com/jvrousseau/turf.git
+	branch = update-examples

--- a/docs/index.html
+++ b/docs/index.html
@@ -725,16 +725,6 @@
               
                 
                 <li><a
-                  href='#centerofmass'
-                  class="">
-                  centerOfMass
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#circle'
                   class="">
                   circle
@@ -745,29 +735,9 @@
               
                 
                 <li><a
-                  href='#index'
-                  class="">
-                  index
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#geojsontype'
                   class="">
                   geojsonType
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#lineslicealong'
-                  class="">
-                  lineSliceAlong
                   
                 </a>
                 
@@ -788,16 +758,6 @@
                   href='#coordall'
                   class="">
                   coordAll
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#geomeach'
-                  class="">
-                  geomEach
                   
                 </a>
                 
@@ -846,11 +806,11 @@
   </div>
   
 
-  <p>Merges a specified property from a FeatureCollection of points into a
-FeatureCollection of polygons. Given an <code>inProperty</code> on points and an <code>outProperty</code>
-for polygons, this finds every point that lies within each polygon, collects the
-<code>inProperty</code> values from those points, and adds them as an array to <code>outProperty</code>
-on the polygon.</p>
+  <p>Joins attributes FeatureCollection of polygons with a FeatureCollection of
+points. Given an <code>inProperty</code> on points and an <code>outProperty</code> for polygons,
+this finds every point that lies within each polygon, collects the <code>inProperty</code>
+values from those points, and adds them as an array to <code>outProperty</code> on the
+polygon.</p>
 
 
   <div class='pre p1 fill-light mt0'>collect</div>
@@ -921,18 +881,18 @@ on the polygon.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> poly1 = turf.polygon([[[<span class="hljs-number">0</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">10</span>],[<span class="hljs-number">0</span>,<span class="hljs-number">10</span>],[<span class="hljs-number">0</span>,<span class="hljs-number">0</span>]]]);
-<span class="hljs-keyword">var</span> poly2 = turf.polygon([[[<span class="hljs-number">10</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">20</span>,<span class="hljs-number">10</span>],[<span class="hljs-number">20</span>,<span class="hljs-number">20</span>],[<span class="hljs-number">20</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">0</span>]]]);
-<span class="hljs-keyword">var</span> polyFC = turf.featureCollection([poly1, poly2]);
-<span class="hljs-keyword">var</span> pt1 = turf.point([<span class="hljs-number">5</span>,<span class="hljs-number">5</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">200</span>});
-<span class="hljs-keyword">var</span> pt2 = turf.point([<span class="hljs-number">1</span>,<span class="hljs-number">3</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">600</span>});
-<span class="hljs-keyword">var</span> pt3 = turf.point([<span class="hljs-number">14</span>,<span class="hljs-number">2</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">100</span>});
-<span class="hljs-keyword">var</span> pt4 = turf.point([<span class="hljs-number">13</span>,<span class="hljs-number">1</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">200</span>});
-<span class="hljs-keyword">var</span> pt5 = turf.point([<span class="hljs-number">19</span>,<span class="hljs-number">7</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">300</span>});
-<span class="hljs-keyword">var</span> ptFC = turf.featureCollection([pt1, pt2, pt3, pt4, pt5]);
-<span class="hljs-keyword">var</span> collected = turf.collect(polyFC, ptFC, <span class="hljs-string">'population'</span>, <span class="hljs-string">'values'</span>);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> poly1 = polygon([[[<span class="hljs-number">0</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">10</span>],[<span class="hljs-number">0</span>,<span class="hljs-number">10</span>],[<span class="hljs-number">0</span>,<span class="hljs-number">0</span>]]]);
+<span class="hljs-keyword">var</span> poly2 = polygon([[[<span class="hljs-number">10</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">20</span>,<span class="hljs-number">10</span>],[<span class="hljs-number">20</span>,<span class="hljs-number">20</span>],[<span class="hljs-number">20</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">0</span>]]]);
+<span class="hljs-keyword">var</span> polyFC = featurecollection([poly1, poly2]);
+<span class="hljs-keyword">var</span> pt1 = point([<span class="hljs-number">5</span>,<span class="hljs-number">5</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">200</span>});
+<span class="hljs-keyword">var</span> pt2 = point([<span class="hljs-number">1</span>,<span class="hljs-number">3</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">600</span>});
+<span class="hljs-keyword">var</span> pt3 = point([<span class="hljs-number">14</span>,<span class="hljs-number">2</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">100</span>});
+<span class="hljs-keyword">var</span> pt4 = point([<span class="hljs-number">13</span>,<span class="hljs-number">1</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">200</span>});
+<span class="hljs-keyword">var</span> pt5 = point([<span class="hljs-number">19</span>,<span class="hljs-number">7</span>], {<span class="hljs-attr">population</span>: <span class="hljs-number">300</span>});
+<span class="hljs-keyword">var</span> ptFC = featurecollection([pt1, pt2, pt3, pt4, pt5]);
+<span class="hljs-keyword">var</span> aggregated = aggregate(polyFC, ptFC, <span class="hljs-string">'population'</span>, <span class="hljs-string">'values'</span>);
 
-collected.features[<span class="hljs-number">0</span>].properties.values <span class="hljs-comment">// =&gt; [200, 600]);</span></pre>
+aggregated.features[<span class="hljs-number">0</span>].properties.values <span class="hljs-comment">// =&gt; [200, 600]);</span></pre>
     
   
 
@@ -1004,8 +964,8 @@ collected.features[<span class="hljs-number">0</span>].properties.values <span c
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
+            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>]
+            (default <code>miles</code>)
             )</code> can be degrees, radians, miles, or kilometers
 
           </div>
@@ -1085,11 +1045,11 @@ collected.features[<span class="hljs-number">0</span>].properties.values <span c
   </div>
   
 
-  <p>Takes one or more features and returns their area
+  <p>Takes a one or more features and returns their area
 in square meters.</p>
 
 
-  <div class='pre p1 fill-light mt0'>area(input: (<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> | <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>)): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  <div class='pre p1 fill-light mt0'>area(input: (<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> | <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>)): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></div>
 
   
 
@@ -1119,7 +1079,7 @@ in square meters.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>:
         area in square meters
 
       
@@ -1211,9 +1171,8 @@ in square meters.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>bbox</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;)</code> extent in 
-[minX, minY, maxX, maxY]
- order
+            <span class='code bold'>bbox</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;)</code> an Array of bounding box coordinates in the form: 
+<code>[xLow, yLow, xHigh, yHigh]</code>
 
           </div>
           
@@ -1310,7 +1269,7 @@ in square meters.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>:
         bearing in decimal degrees
 
       
@@ -1378,7 +1337,7 @@ in square meters.</p>
   </div>
   
 
-  <p>Takes a <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> or <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a> and returns the absolute center point of all features.</p>
+  <p>Takes a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a> and returns the absolute center point of all features.</p>
 
 
   <div class='pre p1 fill-light mt0'>center</div>
@@ -1397,7 +1356,7 @@ in square meters.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>layer</span> <code class='quiet'>((<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> | <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>))</code> input features
+            <span class='code bold'>features</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>)</code> input features
 
           </div>
           
@@ -1412,7 +1371,8 @@ in square meters.</p>
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;</code>:
-        a Point feature at the absolute center point of all input features
+        a Point feature at the
+absolute center point of all input features
 
       
     
@@ -1689,7 +1649,7 @@ the centroid of a set of polygons.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>]
             (default <code>kilometers</code>)
             )</code> miles, kilometers, degrees, or radians
 
@@ -1803,7 +1763,7 @@ to account for global curvature.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>]
             (default <code>kilometers</code>)
             )</code> can be degrees, radians, miles, or kilometers
 
@@ -1819,7 +1779,7 @@ to account for global curvature.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>:
         distance between the two points
 
       
@@ -1903,7 +1863,7 @@ to account for global curvature.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>features</span> <code class='quiet'>((<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> | <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>))</code> input features
+            <span class='code bold'>fc</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>)</code> input features
 
           </div>
           
@@ -1997,7 +1957,7 @@ to account for global curvature.</p>
   </div>
   
 
-  <p>Takes a <a href="http://geojson.org/geojson-spec.html#linestring">LineString</a> or <a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a> and measures its length in the specified units.</p>
+  <p>Takes a <a href="http://geojson.org/geojson-spec.html#linestring">line</a> and measures its length in the specified units.</p>
 
 
   <div class='pre p1 fill-light mt0'>lineDistance</div>
@@ -2016,7 +1976,7 @@ to account for global curvature.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>line</span> <code class='quiet'>((<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;(<a href="http://geojson.org/geojson-spec.html#linestring">LineString</a> | <a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>)&gt; | <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;(<a href="http://geojson.org/geojson-spec.html#linestring">LineString</a> | <a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>)&gt;))</code> line to measure
+            <span class='code bold'>line</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#linestring">LineString</a>&gt;)</code> line to measure
 
           </div>
           
@@ -2024,7 +1984,7 @@ to account for global curvature.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>]
             (default <code>kilometers</code>)
             )</code> can be degrees, radians, miles, or kilometers
 
@@ -2040,7 +2000,7 @@ to account for global curvature.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>:
         length of the input line
 
       
@@ -2317,9 +2277,7 @@ would contain the input.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>bbox</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;)</code> extent in 
-[minX, minY, maxX, maxY]
- order
+            <span class='code bold'>bbox</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;)</code> a bounding box
 
           </div>
           
@@ -2426,7 +2384,7 @@ algorithm.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>resolution</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
+            <span class='code bold'>resolution</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>]
             (default <code>10000</code>)
             )</code> time in milliseconds between points
 
@@ -2436,7 +2394,7 @@ algorithm.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>sharpness</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
+            <span class='code bold'>sharpness</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>]
             (default <code>0.85</code>)
             )</code> a measure of how curvy the path should be between splines
 
@@ -2543,7 +2501,7 @@ curved.properties = { <span class="hljs-attr">stroke</span>: <span class="hljs-s
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>radius</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> distance to draw the buffer
+            <span class='code bold'>distance</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> distance to draw the buffer
 
           </div>
           
@@ -2551,7 +2509,7 @@ curved.properties = { <span class="hljs-attr">stroke</span>: <span class="hljs-s
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> any of the options supported by turf units
+            <span class='code bold'>unit</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> any of the options supported by turf units
 
           </div>
           
@@ -2620,7 +2578,7 @@ curved.properties = { <span class="hljs-attr">stroke</span>: <span class="hljs-s
 <p>Internally, this uses <a href="https://github.com/Turfjs/turf-tin">turf-tin</a> to generate geometries.</p>
 
 
-  <div class='pre p1 fill-light mt0'>concave(points: <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;, maxEdge: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, units: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]): <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;</div>
+  <div class='pre p1 fill-light mt0'>concave(points: <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;, maxEdge: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, units: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;</div>
 
   
 
@@ -2653,9 +2611,7 @@ hull to become concave (in miles)
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> can be degrees, radians, miles, or kilometers
+            <span class='code bold'>units</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> used for maxEdge distance (miles or kilometers)
 
           </div>
           
@@ -2681,6 +2637,9 @@ hull to become concave (in miles)
     <ul>
       
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if maxEdge parameter is missing
+</li>
+      
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>: if units parameter is missing
 </li>
       
     </ul>
@@ -2772,9 +2731,8 @@ hull to become concave (in miles)
   </div>
   
 
-  <p>Takes a <a href="http://geojson.org/geojson-spec.html#feature-objects">feature</a>
-or a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">featureCollection</a>
-and returns a <a href="http://en.wikipedia.org/wiki/Convex_hull">convex hull</a> polygon.</p>
+  <p>Takes a set of <a href="http://geojson.org/geojson-spec.html#point">points</a> and returns a
+<a href="http://en.wikipedia.org/wiki/Convex_hull">convex hull</a> polygon.</p>
 <p>Internally this uses
 the <a href="https://github.com/mikolalysenko/convex-hull">convex-hull</a> module that
 implements a <a href="http://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain">monotone chain hull</a>.</p>
@@ -2796,7 +2754,7 @@ implements a <a href="http://en.wikibooks.org/wiki/Algorithm_Implementation/Geom
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>feature</span> <code class='quiet'>((<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> | <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>))</code> input Feature or FeatureCollection
+            <span class='code bold'>featurecollection</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> input points
 
           </div>
           
@@ -2925,7 +2883,7 @@ polygon from the first.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>p1</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> input Polygon feature
+            <span class='code bold'>poly1</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> input Polygon feaure
 
           </div>
           
@@ -2933,8 +2891,8 @@ polygon from the first.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>p2</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> Polygon feature to difference from 
-<code>p1</code>
+            <span class='code bold'>poly2</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> Polygon feature to difference from 
+<code>poly1</code>
 
           </div>
           
@@ -2950,9 +2908,9 @@ polygon from the first.</p>
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;</code>:
         a Polygon feature showing the area of 
-<code>p1</code>
+<code>poly1</code>
  excluding the area of 
-<code>p2</code>
+<code>poly2</code>
 
       
     
@@ -3073,22 +3031,22 @@ differenced.properties.fill = <span class="hljs-string">'#f00'</span>;
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a>)</code>:
-        returns a feature representing the point(s) they share (in case of a 
-<a href="http://geojson.org/geojson-spec.html#point">Point</a>
-  or 
-<a href="http://geojson.org/geojson-spec.html#multipoint">MultiPoint</a>
-), the borders they share (in case of a 
-<a href="http://geojson.org/geojson-spec.html#linestring">LineString</a>
- or a 
-<a href="http://geojson.org/geojson-spec.html#multilinestring">MultiLineString</a>
-), the area they share (in case of 
-<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>
- or 
-<a href="http://geojson.org/geojson-spec.html#multipolygon">MultiPolygon</a>
-). If they do not share any point, returns 
+      <code>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt; | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a> | <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#multilinestring">MultiLineString</a>&gt;)</code>:
+        if 
+<code>poly1</code>
+ and 
+<code>poly2</code>
+ overlap, returns a Polygon feature representing the area they overlap; if 
+<code>poly1</code>
+ and 
+<code>poly2</code>
+ do not overlap, returns 
 <code>undefined</code>
-.
+; if 
+<code>poly1</code>
+ and 
+<code>poly2</code>
+ share a border, a MultiLineString of the locations where their borders are shared
 
       
     
@@ -3100,26 +3058,50 @@ differenced.properties.fill = <span class="hljs-string">'#f00'</span>;
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> poly1 = polygon([[
-  [<span class="hljs-number">-122.801742</span>, <span class="hljs-number">45.48565</span>],
-  [<span class="hljs-number">-122.801742</span>, <span class="hljs-number">45.60491</span>],
-  [<span class="hljs-number">-122.584762</span>, <span class="hljs-number">45.60491</span>],
-  [<span class="hljs-number">-122.584762</span>, <span class="hljs-number">45.48565</span>],
-  [<span class="hljs-number">-122.801742</span>, <span class="hljs-number">45.48565</span>]
-]]);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> poly1 = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+  <span class="hljs-string">"properties"</span>: {
+    <span class="hljs-string">"fill"</span>: <span class="hljs-string">"#0f0"</span>
+  },
+  <span class="hljs-string">"geometry"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Polygon"</span>,
+    <span class="hljs-string">"coordinates"</span>: [[
+      [<span class="hljs-number">-122.801742</span>, <span class="hljs-number">45.48565</span>],
+      [<span class="hljs-number">-122.801742</span>, <span class="hljs-number">45.60491</span>],
+      [<span class="hljs-number">-122.584762</span>, <span class="hljs-number">45.60491</span>],
+      [<span class="hljs-number">-122.584762</span>, <span class="hljs-number">45.48565</span>],
+      [<span class="hljs-number">-122.801742</span>, <span class="hljs-number">45.48565</span>]
+    ]]
+  }
+}
+<span class="hljs-keyword">var</span> poly2 = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+  <span class="hljs-string">"properties"</span>: {
+    <span class="hljs-string">"fill"</span>: <span class="hljs-string">"#00f"</span>
+  },
+  <span class="hljs-string">"geometry"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Polygon"</span>,
+    <span class="hljs-string">"coordinates"</span>: [[
+      [<span class="hljs-number">-122.520217</span>, <span class="hljs-number">45.535693</span>],
+      [<span class="hljs-number">-122.64038</span>, <span class="hljs-number">45.553967</span>],
+      [<span class="hljs-number">-122.720031</span>, <span class="hljs-number">45.526554</span>],
+      [<span class="hljs-number">-122.669906</span>, <span class="hljs-number">45.507309</span>],
+      [<span class="hljs-number">-122.723464</span>, <span class="hljs-number">45.446643</span>],
+      [<span class="hljs-number">-122.532577</span>, <span class="hljs-number">45.408574</span>],
+      [<span class="hljs-number">-122.487258</span>, <span class="hljs-number">45.477466</span>],
+      [<span class="hljs-number">-122.520217</span>, <span class="hljs-number">45.535693</span>]
+    ]]
+  }
+}
 
-<span class="hljs-keyword">var</span> poly2 = polygon([[
-  [<span class="hljs-number">-122.520217</span>, <span class="hljs-number">45.535693</span>],
-  [<span class="hljs-number">-122.64038</span>, <span class="hljs-number">45.553967</span>],
-  [<span class="hljs-number">-122.720031</span>, <span class="hljs-number">45.526554</span>],
-  [<span class="hljs-number">-122.669906</span>, <span class="hljs-number">45.507309</span>],
-  [<span class="hljs-number">-122.723464</span>, <span class="hljs-number">45.446643</span>],
-  [<span class="hljs-number">-122.532577</span>, <span class="hljs-number">45.408574</span>],
-  [<span class="hljs-number">-122.487258</span>, <span class="hljs-number">45.477466</span>],
-  [<span class="hljs-number">-122.520217</span>, <span class="hljs-number">45.535693</span>]
-]]);
+<span class="hljs-keyword">var</span> polygons = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"FeatureCollection"</span>,
+  <span class="hljs-string">"features"</span>: [poly1, poly2]
+};
 
 <span class="hljs-keyword">var</span> intersection = turf.intersect(poly1, poly2);
+
+<span class="hljs-comment">//=polygons</span>
 
 <span class="hljs-comment">//=intersection</span></pre>
     
@@ -3173,9 +3155,7 @@ differenced.properties.fill = <span class="hljs-string">'#f00'</span>;
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>tolerance</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
-            (default <code>1</code>)
-            )</code> simplification tolerance
+            <span class='code bold'>tolerance</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> simplification tolerance
 
           </div>
           
@@ -3183,9 +3163,7 @@ differenced.properties.fill = <span class="hljs-string">'#f00'</span>;
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>highQuality</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>]
-            (default <code>false</code>)
-            )</code> whether or not to spend more time to create
+            <span class='code bold'>highQuality</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code> whether or not to spend more time to create
 a higher-quality simplification with a different algorithm
 
           </div>
@@ -3275,7 +3253,7 @@ a higher-quality simplification with a different algorithm
   </div>
   
 
-  <p>Takes two or more <a href="http://geojson.org/geojson-spec.html#polygon">polygons</a> and returns a combined polygon. If the input polygons are not contiguous, this function returns a <a href="http://geojson.org/geojson-spec.html#multipolygon">MultiPolygon</a> feature.</p>
+  <p>Takes two <a href="http://geojson.org/geojson-spec.html#polygon">polygons</a> and returns a combined polygon. If the input polygons are not contiguous, this function returns a <a href="http://geojson.org/geojson-spec.html#multipolygon">MultiPolygon</a> feature.</p>
 
 
   <div class='pre p1 fill-light mt0'>union</div>
@@ -3294,7 +3272,15 @@ a higher-quality simplification with a different algorithm
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>A</span> <code class='quiet'>(...<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> polygon to combine
+            <span class='code bold'>poly1</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> input polygon
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>poly2</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> another input polygon
 
           </div>
           
@@ -3804,7 +3790,7 @@ The start &amp; stop points don&#x27;t need to fall exactly on the line.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>startPt</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> starting point
+            <span class='code bold'>point1</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> starting point
 
           </div>
           
@@ -3812,7 +3798,7 @@ The start &amp; stop points don&#x27;t need to fall exactly on the line.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>stopPt</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> stopping point
+            <span class='code bold'>point2</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> stopping point
 
           </div>
           
@@ -3935,17 +3921,7 @@ The start &amp; stop points don&#x27;t need to fall exactly on the line.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>pt</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> point to snap from
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> can be degrees, radians, miles, or kilometers
+            <span class='code bold'>point</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> point to snap from
 
           </div>
           
@@ -3999,7 +3975,7 @@ The start &amp; stop points don&#x27;t need to fall exactly on the line.</p>
   }
 };
 
-<span class="hljs-keyword">var</span> snapped = turf.pointOnLine(line, pt, <span class="hljs-string">'miles'</span>);
+<span class="hljs-keyword">var</span> snapped = turf.pointOnLine(line, pt);
 snapped.properties[<span class="hljs-string">'marker-color'</span>] = <span class="hljs-string">'#00f'</span>
 
 <span class="hljs-keyword">var</span> result = {
@@ -4809,7 +4785,7 @@ coordinate array. Properties can be added optionally.</p>
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#geometrycollection">GeometryCollection</a>&gt;</code>:
-        a GeoJSON GeometryCollection Feature
+        a geometrycollection feature
 
       
     
@@ -4829,7 +4805,7 @@ coordinate array. Properties can be added optionally.</p>
     <span class="hljs-string">"type"</span>: <span class="hljs-string">"LineString"</span>,
     <span class="hljs-string">"coordinates"</span>: [ [<span class="hljs-number">101</span>, <span class="hljs-number">0</span>], [<span class="hljs-number">102</span>, <span class="hljs-number">1</span>] ]
   };
-<span class="hljs-keyword">var</span> collection = turf.geometryCollection([pt, line]);
+<span class="hljs-keyword">var</span> collection = turf.geometrycollection([[<span class="hljs-number">0</span>,<span class="hljs-number">0</span>],[<span class="hljs-number">10</span>,<span class="hljs-number">10</span>]]);
 
 <span class="hljs-comment">//=collection</span></pre>
     
@@ -4888,7 +4864,7 @@ and experimentation.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>type</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>type</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>]
             (default <code>&#39;point&#39;</code>)
             )</code> type of features desired: &#x27;points&#x27; or &#x27;polygons&#x27;
 
@@ -4898,7 +4874,7 @@ and experimentation.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>count</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
+            <span class='code bold'>count</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>]
             (default <code>1</code>)
             )</code> how many geometries should be generated.
 
@@ -4939,7 +4915,7 @@ while
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>options.num_vertices</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]</code>
+                  <td class='break-word'><span class='code bold'>options.num_vertices</span> <code class='quiet'>[<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>]</code>
                   
                     (default <code>10</code>)
                   </td>
@@ -5271,7 +5247,7 @@ that define the values at its three corners.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>:
         the z-value for 
 <code>interpolatedPoint</code>
 
@@ -5507,7 +5483,7 @@ be convex or concave. The function accounts for holes.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></code>:
         <code>true</code>
  if the Point is inside the Polygon; 
 <code>false</code>
@@ -5523,18 +5499,53 @@ be convex or concave. The function accounts for holes.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> pt = point([<span class="hljs-number">-77</span>, <span class="hljs-number">44</span>]);
-<span class="hljs-keyword">var</span> poly = polygon([[
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">41</span>],
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">47</span>],
-  [<span class="hljs-number">-72</span>, <span class="hljs-number">47</span>],
-  [<span class="hljs-number">-72</span>, <span class="hljs-number">41</span>],
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">41</span>]
-]]);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> pt1 = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+  <span class="hljs-string">"properties"</span>: {
+    <span class="hljs-string">"marker-color"</span>: <span class="hljs-string">"#f00"</span>
+  },
+  <span class="hljs-string">"geometry"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+    <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">-111.467285</span>, <span class="hljs-number">40.75766</span>]
+  }
+};
+<span class="hljs-keyword">var</span> pt2 = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+  <span class="hljs-string">"properties"</span>: {
+    <span class="hljs-string">"marker-color"</span>: <span class="hljs-string">"#0f0"</span>
+  },
+  <span class="hljs-string">"geometry"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+    <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">-111.873779</span>, <span class="hljs-number">40.647303</span>]
+  }
+};
+<span class="hljs-keyword">var</span> poly = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+  <span class="hljs-string">"properties"</span>: {},
+  <span class="hljs-string">"geometry"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Polygon"</span>,
+    <span class="hljs-string">"coordinates"</span>: [[
+      [<span class="hljs-number">-112.074279</span>, <span class="hljs-number">40.52215</span>],
+      [<span class="hljs-number">-112.074279</span>, <span class="hljs-number">40.853293</span>],
+      [<span class="hljs-number">-111.610107</span>, <span class="hljs-number">40.853293</span>],
+      [<span class="hljs-number">-111.610107</span>, <span class="hljs-number">40.52215</span>],
+      [<span class="hljs-number">-112.074279</span>, <span class="hljs-number">40.52215</span>]
+    ]]
+  }
+};
 
-<span class="hljs-keyword">var</span> isInside = turf.inside(pt, poly);
+<span class="hljs-keyword">var</span> features = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"FeatureCollection"</span>,
+  <span class="hljs-string">"features"</span>: [pt1, pt2, poly]
+};
 
-<span class="hljs-comment">//=isInside</span></pre>
+<span class="hljs-comment">//=features</span>
+
+<span class="hljs-keyword">var</span> isInside1 = turf.inside(pt1, poly);
+<span class="hljs-comment">//=isInside1</span>
+
+<span class="hljs-keyword">var</span> isInside2 = turf.inside(pt2, poly);
+<span class="hljs-comment">//=isInside2</span></pre>
     
   
 
@@ -5596,9 +5607,7 @@ be convex or concave. The function accounts for holes.</p>
           <div>
             <span class='code bold'>field</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> property in 
 <code>polygons</code>
- to add to joined {
-<Point>
-} features
+ to add to joined Point features
 
           </div>
           
@@ -5608,8 +5617,7 @@ be convex or concave. The function accounts for holes.</p>
           <div>
             <span class='code bold'>outField</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> property in 
 <code>points</code>
- in which to store joined property from 
-<code>polygons</code>
+ in which to store joined property from &#x60;polygons
 
           </div>
           
@@ -5639,28 +5647,27 @@ be convex or concave. The function accounts for holes.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> pt1 = point([<span class="hljs-number">-77</span>, <span class="hljs-number">44</span>]);
-<span class="hljs-keyword">var</span> pt2 = point([<span class="hljs-number">-77</span>, <span class="hljs-number">38</span>]);
-<span class="hljs-keyword">var</span> poly1 = polygon([[
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">41</span>],
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">47</span>],
-  [<span class="hljs-number">-72</span>, <span class="hljs-number">47</span>],
-  [<span class="hljs-number">-72</span>, <span class="hljs-number">41</span>],
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">41</span>]
-]], {<span class="hljs-attr">pop</span>: <span class="hljs-number">3000</span>});
-<span class="hljs-keyword">var</span> poly2 = polygon([[
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">35</span>],
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">41</span>],
-  [<span class="hljs-number">-72</span>, <span class="hljs-number">41</span>],
-  [<span class="hljs-number">-72</span>, <span class="hljs-number">35</span>],
-  [<span class="hljs-number">-81</span>, <span class="hljs-number">35</span>]
-]], {<span class="hljs-attr">pop</span>: <span class="hljs-number">1000</span>});
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> bbox = [<span class="hljs-number">0</span>, <span class="hljs-number">0</span>, <span class="hljs-number">10</span>, <span class="hljs-number">10</span>];
+<span class="hljs-comment">// create a triangular grid of polygons</span>
+<span class="hljs-keyword">var</span> triangleGrid = turf.triangleGrid(bbox, <span class="hljs-number">50</span>, <span class="hljs-string">'miles'</span>);
+triangleGrid.features.forEach(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">f</span>) </span>{
+  f.properties.fill = <span class="hljs-string">'#'</span> +
+    (~~(<span class="hljs-built_in">Math</span>.random() * <span class="hljs-number">16</span>)).toString(<span class="hljs-number">16</span>) +
+    (~~(<span class="hljs-built_in">Math</span>.random() * <span class="hljs-number">16</span>)).toString(<span class="hljs-number">16</span>) +
+    (~~(<span class="hljs-built_in">Math</span>.random() * <span class="hljs-number">16</span>)).toString(<span class="hljs-number">16</span>);
+  f.properties.stroke = <span class="hljs-number">0</span>;
+  f.properties[<span class="hljs-string">'fill-opacity'</span>] = <span class="hljs-number">1</span>;
+});
+<span class="hljs-keyword">var</span> randomPoints = turf.random(<span class="hljs-string">'point'</span>, <span class="hljs-number">30</span>, {
+  <span class="hljs-attr">bbox</span>: bbox
+});
+<span class="hljs-keyword">var</span> both = turf.featurecollection(
+  triangleGrid.features.concat(randomPoints.features));
 
-<span class="hljs-keyword">var</span> points = featureCollection([pt1, pt2]);
-<span class="hljs-keyword">var</span> polygons = featureCollection([poly1, poly2]);
+<span class="hljs-comment">//=both</span>
 
-<span class="hljs-keyword">var</span> tagged = turf.tag(points, polygons,
-                      <span class="hljs-string">'pop'</span>, <span class="hljs-string">'population'</span>);
+<span class="hljs-keyword">var</span> tagged = turf.tag(randomPoints, triangleGrid,
+                      <span class="hljs-string">'fill'</span>, <span class="hljs-string">'marker-color'</span>);
 
 <span class="hljs-comment">//=tagged</span></pre>
     
@@ -5720,7 +5727,7 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>bbox</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;)</code> extent in 
+            <span class='code bold'>bbox</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;)</code> bounding box in 
 [minX, minY, maxX, maxY]
  order
 
@@ -5738,9 +5745,7 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> used in calculating cellSize, can be degrees, radians, miles, or kilometers
+            <span class='code bold'>units</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> used in calculating cellWidth (&#x27;miles&#x27; or &#x27;kilometers&#x27;)
 
           </div>
           
@@ -5748,9 +5753,7 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>triangles</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>]
-            (default <code>false</code>)
-            )</code> whether to return as triangles instead of hexagons
+            <span class='code bold'>triangles</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code> whether to return as triangles instead of hexagons
 
           </div>
           
@@ -5778,10 +5781,10 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> bbox = [<span class="hljs-number">-96</span>,<span class="hljs-number">31</span>,<span class="hljs-number">-84</span>,<span class="hljs-number">40</span>];
-<span class="hljs-keyword">var</span> cellSize = <span class="hljs-number">50</span>;
+<span class="hljs-keyword">var</span> cellWidth = <span class="hljs-number">50</span>;
 <span class="hljs-keyword">var</span> units = <span class="hljs-string">'miles'</span>;
 
-<span class="hljs-keyword">var</span> hexgrid = turf.hexGrid(bbox, cellSize, units);
+<span class="hljs-keyword">var</span> hexgrid = turf.hexGrid(bbox, cellWidth, units);
 
 <span class="hljs-comment">//=hexgrid</span></pre>
     
@@ -5847,7 +5850,7 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
           <div>
             <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
             (default <code>kilometers</code>)
-            )</code> used in calculating cellSize, can be degrees, radians, miles, or kilometers
+            )</code> used in calculating cellWidth, can be degrees, radians, miles, or kilometers
 
           </div>
           
@@ -5875,10 +5878,10 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> extent = [<span class="hljs-number">-70.823364</span>, <span class="hljs-number">-33.553984</span>, <span class="hljs-number">-70.473175</span>, <span class="hljs-number">-33.302986</span>];
-<span class="hljs-keyword">var</span> cellSize = <span class="hljs-number">3</span>;
+<span class="hljs-keyword">var</span> cellWidth = <span class="hljs-number">3</span>;
 <span class="hljs-keyword">var</span> units = <span class="hljs-string">'miles'</span>;
 
-<span class="hljs-keyword">var</span> grid = turf.pointGrid(extent, cellSize, units);
+<span class="hljs-keyword">var</span> grid = turf.pointGrid(extent, cellWidth, units);
 
 <span class="hljs-comment">//=grid</span></pre>
     
@@ -5942,9 +5945,7 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> used in calculating cellSize, can be degrees, radians, miles, or kilometers
+            <span class='code bold'>units</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> units to use for cellWidth
 
           </div>
           
@@ -5971,11 +5972,11 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> bbox = [<span class="hljs-number">-96</span>,<span class="hljs-number">31</span>,<span class="hljs-number">-84</span>,<span class="hljs-number">40</span>];
-<span class="hljs-keyword">var</span> cellSize = <span class="hljs-number">10</span>;
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> extent = [<span class="hljs-number">-77.3876953125</span>,<span class="hljs-number">38.71980474264239</span>,<span class="hljs-number">-76.9482421875</span>,<span class="hljs-number">39.027718840211605</span>];
+<span class="hljs-keyword">var</span> cellWidth = <span class="hljs-number">10</span>;
 <span class="hljs-keyword">var</span> units = <span class="hljs-string">'miles'</span>;
 
-<span class="hljs-keyword">var</span> squareGrid = turf.squareGrid(bbox, cellSize, units);
+<span class="hljs-keyword">var</span> squareGrid = turf.squareGrid(extent, cellWidth, units);
 
 <span class="hljs-comment">//=squareGrid</span></pre>
     
@@ -6039,9 +6040,7 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> used in calculating cellSize, can be degrees, radians, miles, or kilometers
+            <span class='code bold'>units</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> units to use for cellWidth
 
           </div>
           
@@ -6068,11 +6067,11 @@ described in <a href="http://www.redblobgames.com/grids/hexagons/">Hexagonal Gri
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> bbox = [<span class="hljs-number">-96</span>,<span class="hljs-number">31</span>,<span class="hljs-number">-84</span>,<span class="hljs-number">40</span>]
-<span class="hljs-keyword">var</span> cellSize = <span class="hljs-number">10</span>;
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> extent = [<span class="hljs-number">-77.3876953125</span>,<span class="hljs-number">38.71980474264239</span>,<span class="hljs-number">-76.9482421875</span>,<span class="hljs-number">39.027718840211605</span>];
+<span class="hljs-keyword">var</span> cellWidth = <span class="hljs-number">10</span>;
 <span class="hljs-keyword">var</span> units = <span class="hljs-string">'miles'</span>;
 
-<span class="hljs-keyword">var</span> triangleGrid = turf.triangleGrid(extent, cellSize, units);
+<span class="hljs-keyword">var</span> triangleGrid = turf.triangleGrid(extent, cellWidth, units);
 
 <span class="hljs-comment">//=triangleGrid</span></pre>
     
@@ -6404,7 +6403,7 @@ nearest.properties[<span class="hljs-string">'marker-color'</span>] = <span clas
 Array.forEach.</p>
 
 
-  <div class='pre p1 fill-light mt0'>propEach</div>
+  <div class='pre p1 fill-light mt0'>propEach(layer: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, callback: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">Function</a>)</div>
 
   
 
@@ -6479,7 +6478,7 @@ propEach(point, <span class="hljs-function"><span class="hljs-keyword">function<
 Array.forEach.</p>
 
 
-  <div class='pre p1 fill-light mt0'>coordEach</div>
+  <div class='pre p1 fill-light mt0'>coordEach(layer: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, callback: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">Function</a>, excludeWrapCoord: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>])</div>
 
   
 
@@ -6564,7 +6563,7 @@ similar to how Array.reduce works. However, in this case we lazily run
 the reduction, so an array of all coordinates is unnecessary.</p>
 
 
-  <div class='pre p1 fill-light mt0'>coordReduce</div>
+  <div class='pre p1 fill-light mt0'>coordReduce(layer: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, callback: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">Function</a>, memo: Any, excludeWrapCoord: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>]): Any</div>
 
   
 
@@ -6656,7 +6655,7 @@ the final coordinate of LinearRings that wraps the ring in its iteration.
 Array.forEach.</p>
 
 
-  <div class='pre p1 fill-light mt0'>featureEach</div>
+  <div class='pre p1 fill-light mt0'>featureEach(layer: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, callback: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">Function</a>)</div>
 
   
 
@@ -7003,9 +7002,10 @@ Internally this uses <a href="#geojsontype">geojsonType</a> to judge geometry ty
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;</code>:
-        bbox extent in 
-[minX, minY, maxX, maxY]
- order
+        the bounding box of 
+<code>input</code>
+ given
+as an array in WSEN order (west, south, east, north)
 
       
     
@@ -7017,188 +7017,52 @@ Internally this uses <a href="#geojsontype">geojsonType</a> to judge geometry ty
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> pt1 = point([<span class="hljs-number">114.175329</span>, <span class="hljs-number">22.2524</span>])
-<span class="hljs-keyword">var</span> pt2 = point([<span class="hljs-number">114.170007</span>, <span class="hljs-number">22.267969</span>])
-<span class="hljs-keyword">var</span> pt3 = point([<span class="hljs-number">114.200649</span>, <span class="hljs-number">22.274641</span>])
-<span class="hljs-keyword">var</span> pt4 = point([<span class="hljs-number">114.200649</span>, <span class="hljs-number">22.274641</span>])
-<span class="hljs-keyword">var</span> pt5 = point([<span class="hljs-number">114.186744</span>, <span class="hljs-number">22.265745</span>])
-<span class="hljs-keyword">var</span> features = featureCollection([pt1, pt2, pt3, pt4, pt5])
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> input = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"FeatureCollection"</span>,
+  <span class="hljs-string">"features"</span>: [
+    {
+      <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+      <span class="hljs-string">"properties"</span>: {},
+      <span class="hljs-string">"geometry"</span>: {
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+        <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">114.175329</span>, <span class="hljs-number">22.2524</span>]
+      }
+    }, {
+      <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+      <span class="hljs-string">"properties"</span>: {},
+      <span class="hljs-string">"geometry"</span>: {
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+        <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">114.170007</span>, <span class="hljs-number">22.267969</span>]
+      }
+    }, {
+      <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+      <span class="hljs-string">"properties"</span>: {},
+      <span class="hljs-string">"geometry"</span>: {
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+        <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">114.200649</span>, <span class="hljs-number">22.274641</span>]
+      }
+    }, {
+      <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+      <span class="hljs-string">"properties"</span>: {},
+      <span class="hljs-string">"geometry"</span>: {
+        <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+        <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">114.186744</span>, <span class="hljs-number">22.265745</span>]
+      }
+    }
+  ]
+};
 
-<span class="hljs-keyword">var</span> bbox = turf.bbox(features);
+<span class="hljs-keyword">var</span> bbox = turf.bbox(input);
 
 <span class="hljs-keyword">var</span> bboxPolygon = turf.bboxPolygon(bbox);
 
-<span class="hljs-comment">//=bbox</span>
-
-<span class="hljs-comment">//=bboxPolygon</span></pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    <h3 class='fl m0' id='centerofmass'>
-      centerOfMass
-    </h3>
-    
-  </div>
-  
-
-  <p>Takes a <a href="http://geojson.org/geojson-spec.html#feature-objects">feature</a>
-or a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">featureCollection</a>
-and returns its <a href="https://en.wikipedia.org/wiki/Center_of_mass">center of mass</a>
-using this formula: <a href="https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon">Centroid of Polygon</a>.</p>
-
-
-  <div class='pre p1 fill-light mt0'>centerOfMass(fc: (<a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a> | <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>)): <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;</div>
-
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>fc</span> <code class='quiet'>((<a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a> | <a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>))</code> the feature collection or feature
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;</code>:
-        the center of mass
-
-      
-    
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> feature = {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
-  <span class="hljs-string">"properties"</span>: {},
-  <span class="hljs-string">"geometry"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Polygon"</span>,
-    <span class="hljs-string">"coordinates"</span>: [
-      [
-        [
-          <span class="hljs-number">4.854240417480469</span>,
-          <span class="hljs-number">45.77258200374433</span>
-        ],
-        [
-          <span class="hljs-number">4.8445844650268555</span>,
-          <span class="hljs-number">45.777431068484894</span>
-        ],
-        [
-          <span class="hljs-number">4.845442771911621</span>,
-          <span class="hljs-number">45.778658234059755</span>
-        ],
-        [
-          <span class="hljs-number">4.845914840698242</span>,
-          <span class="hljs-number">45.779376562352425</span>
-        ],
-        [
-          <span class="hljs-number">4.846644401550292</span>,
-          <span class="hljs-number">45.78021460033108</span>
-        ],
-        [
-          <span class="hljs-number">4.847245216369629</span>,
-          <span class="hljs-number">45.78078326178593</span>
-        ],
-        [
-          <span class="hljs-number">4.848060607910156</span>,
-          <span class="hljs-number">45.78138184652523</span>
-        ],
-        [
-          <span class="hljs-number">4.8487043380737305</span>,
-          <span class="hljs-number">45.78186070968964</span>
-        ],
-        [
-          <span class="hljs-number">4.849562644958495</span>,
-          <span class="hljs-number">45.78248921135124</span>
-        ],
-        [
-          <span class="hljs-number">4.850893020629883</span>,
-          <span class="hljs-number">45.78302792142197</span>
-        ],
-        [
-          <span class="hljs-number">4.852008819580077</span>,
-          <span class="hljs-number">45.78374619341895</span>
-        ],
-        [
-          <span class="hljs-number">4.852995872497559</span>,
-          <span class="hljs-number">45.784075398324866</span>
-        ],
-        [
-          <span class="hljs-number">4.853854179382324</span>,
-          <span class="hljs-number">45.78443452873236</span>
-        ],
-        [
-          <span class="hljs-number">4.8549699783325195</span>,
-          <span class="hljs-number">45.78470387501975</span>
-        ],
-        [
-          <span class="hljs-number">4.85569953918457</span>,
-          <span class="hljs-number">45.784793656826345</span>
-        ],
-        [
-          <span class="hljs-number">4.857330322265624</span>,
-          <span class="hljs-number">45.784853511283764</span>
-        ],
-        [
-          <span class="hljs-number">4.858231544494629</span>,
-          <span class="hljs-number">45.78494329284938</span>
-        ],
-        [
-          <span class="hljs-number">4.859304428100585</span>,
-          <span class="hljs-number">45.784883438488365</span>
-        ],
-        [
-          <span class="hljs-number">4.858360290527344</span>,
-          <span class="hljs-number">45.77294120818474</span>
-        ],
-        [
-          <span class="hljs-number">4.854240417480469</span>,
-          <span class="hljs-number">45.77258200374433</span>
-        ]
-      ]
-    ]
-  }
+<span class="hljs-keyword">var</span> resultFeatures = input.features.concat(bboxPolygon);
+<span class="hljs-keyword">var</span> result = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"FeatureCollection"</span>,
+  <span class="hljs-string">"features"</span>: resultFeatures
 };
 
-<span class="hljs-keyword">var</span> centerOfMass = turf.centerOfMass(feature);
-
-<span class="hljs-comment">//=centerOfMass</span></pre>
+<span class="hljs-comment">//=result</span></pre>
     
   
 
@@ -7258,9 +7122,7 @@ using this formula: <a href="https://en.wikipedia.org/wiki/Centroid#Centroid_of_
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>steps</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
-            (default <code>64</code>)
-            )</code> number of steps
+            <span class='code bold'>steps</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> number of steps
 
           </div>
           
@@ -7268,7 +7130,7 @@ using this formula: <a href="https://en.wikipedia.org/wiki/Centroid#Centroid_of_
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>]
             (default <code>kilometers</code>)
             )</code> miles, kilometers, degrees, or radians
 
@@ -7297,117 +7159,29 @@ using this formula: <a href="https://en.wikipedia.org/wiki/Centroid#Centroid_of_
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> center = point([<span class="hljs-number">-75.343</span>, <span class="hljs-number">39.984</span>]);
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> center = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
+  <span class="hljs-string">"properties"</span>: {
+    <span class="hljs-string">"marker-color"</span>: <span class="hljs-string">"#0f0"</span>
+  },
+  <span class="hljs-string">"geometry"</span>: {
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Point"</span>,
+    <span class="hljs-string">"coordinates"</span>: [<span class="hljs-number">-75.343</span>, <span class="hljs-number">39.984</span>]
+  }
+};
 <span class="hljs-keyword">var</span> radius = <span class="hljs-number">5</span>;
 <span class="hljs-keyword">var</span> steps = <span class="hljs-number">10</span>;
 <span class="hljs-keyword">var</span> units = <span class="hljs-string">'kilometers'</span>;
 
 <span class="hljs-keyword">var</span> circle = turf.circle(center, radius, steps, units);
 
-<span class="hljs-comment">//=circle</span></pre>
+<span class="hljs-keyword">var</span> result = {
+  <span class="hljs-string">"type"</span>: <span class="hljs-string">"FeatureCollection"</span>,
+  <span class="hljs-string">"features"</span>: [center, circle]
+};
+
+<span class="hljs-comment">//=result</span></pre>
     
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    <h3 class='fl m0' id='index'>
-      index
-    </h3>
-    
-  </div>
-  
-
-  <p>Takes a FeatureCollection of points with known value, a power parameter, a cell depth, a unit of measurement
-and returns a FeatureCollection of polygons in a square-grid with an interpolated value property &quot;IDW&quot; for each grid cell.
-It finds application when in need of creating a continuous surface (i.e. rainfall, temperature, chemical dispersion surface...)
-from a set of spatially scattered points.</p>
-
-
-  <div class='pre p1 fill-light mt0'>index(controlPoints: <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;, valueField: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, b: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, cellWidth: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, units: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]): <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;</div>
-
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>controlPoints</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#point">Point</a>&gt;)</code> Sampled points with known value
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>valueField</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code> GeoJSON field containing the known value to interpolate on
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>b</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> Exponent regulating the distance-decay weighting
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>cellWidth</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> The distance across each cell
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> used in calculating cellSize, can be degrees, radians, miles, or kilometers
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollection</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;</code>:
-        grid A grid of polygons with a property field &quot;IDW&quot;
-
-      
-    
-  
-
-  
-
   
 
   
@@ -7505,133 +7279,6 @@ from a set of spatially scattered points.</p>
 
   
   <div class='clearfix'>
-    <h3 class='fl m0' id='lineslicealong'>
-      lineSliceAlong
-    </h3>
-    
-  </div>
-  
-
-  <p>Takes a <a href="http://geojson.org/geojson-spec.html#linestring">line</a>, a specified distance along the line to a start <a href="http://geojson.org/geojson-spec.html#point">Point</a>,
-and a specified  distance along the line to a stop point
-and returns a subsection of the line in-between those points.</p>
-<p>This can be useful for extracting only the part of a route between two distances.</p>
-
-
-  <div class='pre p1 fill-light mt0'>lineSliceAlong</div>
-
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>line</span> <code class='quiet'>((<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#linestring">LineString</a>&gt; | <a href="http://geojson.org/geojson-spec.html#linestring">LineString</a>))</code> input line
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>startDist</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> distance along the line to starting point
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>stopDist</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> distance along the line to ending point
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>units</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
-            (default <code>kilometers</code>)
-            )</code> can be degrees, radians, miles, or kilometers
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#linestring">LineString</a>&gt;</code>:
-        sliced line
-
-      
-    
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> line = {
-  <span class="hljs-string">"type"</span>: <span class="hljs-string">"Feature"</span>,
-  <span class="hljs-string">"properties"</span>: {},
-  <span class="hljs-string">"geometry"</span>: {
-    <span class="hljs-string">"type"</span>: <span class="hljs-string">"LineString"</span>,
-    <span class="hljs-string">"coordinates"</span>: [
-       [ <span class="hljs-number">7.66845703125</span>, <span class="hljs-number">45.058001435398296</span> ],
-      [ <span class="hljs-number">9.20654296875</span>, <span class="hljs-number">45.460130637921004</span> ],
-      [ <span class="hljs-number">11.348876953125</span>, <span class="hljs-number">44.48866833139467</span> ],
-      [ <span class="hljs-number">12.1728515625</span>, <span class="hljs-number">45.43700828867389</span> ],
-      [ <span class="hljs-number">12.535400390625</span>, <span class="hljs-number">43.98491011404692</span> ],
-      [ <span class="hljs-number">12.425537109375</span>, <span class="hljs-number">41.86956082699455</span> ],
-      [ <span class="hljs-number">14.2437744140625</span>, <span class="hljs-number">40.83874913796459</span> ],
-      [ <span class="hljs-number">14.765625</span>, <span class="hljs-number">40.681679458715635</span> ]
-    ]
-  }
-};
-<span class="hljs-keyword">var</span> start = <span class="hljs-number">12.5</span>;
-
-<span class="hljs-keyword">var</span> stop = <span class="hljs-number">25</span>;
-
-<span class="hljs-keyword">var</span> units = <span class="hljs-string">'miles'</span>;
-
-<span class="hljs-keyword">var</span> sliced = turf.lineSliceAlong(start, stop, line, units);
-
-<span class="hljs-comment">//=line</span>
-
-<span class="hljs-comment">//=sliced</span></pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
     <h3 class='fl m0' id='propreduce'>
       propReduce
     </h3>
@@ -7644,7 +7291,7 @@ similar to how Array.reduce works. However, in this case we lazily run
 the reduction, so an array of all properties is unnecessary.</p>
 
 
-  <div class='pre p1 fill-light mt0'>propReduce</div>
+  <div class='pre p1 fill-light mt0'>propReduce(layer: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, callback: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">Function</a>, memo: Any): Any</div>
 
   
 
@@ -7701,22 +7348,6 @@ a new memo
   
 
   
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// an example of an even more advanced function that gives you the</span>
-<span class="hljs-comment">// javascript type of each property of every feature</span>
-<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">propTypes</span> (<span class="hljs-params">layer</span>) </span>{
-  opts = opts || {}
-  <span class="hljs-keyword">return</span> propReduce(layer, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">prev, props</span>) </span>{
-    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> prop <span class="hljs-keyword">in</span> props) {
-      <span class="hljs-keyword">if</span> (prev[prop]) <span class="hljs-keyword">continue</span>
-      prev[prop] = <span class="hljs-keyword">typeof</span> props[prop]
-    }
-  }, {})
-}</pre>
-    
-  
 
   
 
@@ -7743,7 +7374,7 @@ a new memo
 arrays.</p>
 
 
-  <div class='pre p1 fill-light mt0'>coordAll</div>
+  <div class='pre p1 fill-light mt0'>coordAll(layer: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>&gt;&gt;</div>
 
   
 
@@ -7773,7 +7404,7 @@ arrays.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>&gt;&gt;</code>:
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>&gt;&gt;</code>:
         coordinate position array
 
       
@@ -7782,85 +7413,6 @@ arrays.</p>
 
   
 
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    <h3 class='fl m0' id='geomeach'>
-      geomEach
-    </h3>
-    
-  </div>
-  
-
-  <p>Iterate over each geometry in any GeoJSON object, similar to
-Array.forEach.</p>
-
-
-  <div class='pre p1 fill-light mt0'>geomEach</div>
-
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>layer</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code> any GeoJSON object
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>callback</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function">Function</a>)</code> a method that takes (value)
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> point = {
-  <span class="hljs-attr">type</span>: <span class="hljs-string">'Feature'</span>,
-  <span class="hljs-attr">geometry</span>: { <span class="hljs-attr">type</span>: <span class="hljs-string">'Point'</span>, <span class="hljs-attr">coordinates</span>: [<span class="hljs-number">0</span>, <span class="hljs-number">0</span>] },
-  <span class="hljs-attr">properties</span>: {}
-};
-geomEach(point, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">geom</span>) </span>{
-  <span class="hljs-comment">// geom is the point geometry</span>
-});</pre>
-    
   
 
   
@@ -7904,7 +7456,7 @@ using <a href="https://github.com/mapbox/earcut">earcut</a>.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>poly</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> the polygon to tesselate
+            <span class='code bold'>polygon</span> <code class='quiet'>(<a href="http://geojson.org/geojson-spec.html#feature-objects">Feature</a>&lt;<a href="http://geojson.org/geojson-spec.html#polygon">Polygon</a>&gt;)</code> the polygon to tesselate
 
           </div>
           
@@ -7931,9 +7483,9 @@ using <a href="https://github.com/mapbox/earcut">earcut</a>.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> poly = turf.random(<span class="hljs-string">'polygon'</span>).features[<span class="hljs-number">0</span>];
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> polygon = {<span class="hljs-string">"type"</span>:<span class="hljs-string">"Feature"</span>,<span class="hljs-string">"id"</span>:<span class="hljs-string">"USA-CA"</span>,<span class="hljs-string">"properties"</span>:{<span class="hljs-string">"name"</span>:<span class="hljs-string">"California"</span>},<span class="hljs-string">"geometry"</span>:{<span class="hljs-string">"type"</span>:<span class="hljs-string">"Polygon"</span>,<span class="hljs-string">"coordinates"</span>:[[[<span class="hljs-number">-123.233256</span>,<span class="hljs-number">42.006186</span>],[<span class="hljs-number">-122.378853</span>,<span class="hljs-number">42.011663</span>],[<span class="hljs-number">-121.037003</span>,<span class="hljs-number">41.995232</span>],[<span class="hljs-number">-120.001861</span>,<span class="hljs-number">41.995232</span>],[<span class="hljs-number">-119.996384</span>,<span class="hljs-number">40.264519</span>],[<span class="hljs-number">-120.001861</span>,<span class="hljs-number">38.999346</span>],[<span class="hljs-number">-118.71478</span>,<span class="hljs-number">38.101128</span>],[<span class="hljs-number">-117.498899</span>,<span class="hljs-number">37.21934</span>],[<span class="hljs-number">-116.540435</span>,<span class="hljs-number">36.501861</span>],[<span class="hljs-number">-115.85034</span>,<span class="hljs-number">35.970598</span>],[<span class="hljs-number">-114.634459</span>,<span class="hljs-number">35.00118</span>],[<span class="hljs-number">-114.634459</span>,<span class="hljs-number">34.87521</span>],[<span class="hljs-number">-114.470151</span>,<span class="hljs-number">34.710902</span>],[<span class="hljs-number">-114.333228</span>,<span class="hljs-number">34.448009</span>],[<span class="hljs-number">-114.136058</span>,<span class="hljs-number">34.305608</span>],[<span class="hljs-number">-114.256551</span>,<span class="hljs-number">34.174162</span>],[<span class="hljs-number">-114.415382</span>,<span class="hljs-number">34.108438</span>],[<span class="hljs-number">-114.535874</span>,<span class="hljs-number">33.933176</span>],[<span class="hljs-number">-114.497536</span>,<span class="hljs-number">33.697668</span>],[<span class="hljs-number">-114.524921</span>,<span class="hljs-number">33.54979</span>],[<span class="hljs-number">-114.727567</span>,<span class="hljs-number">33.40739</span>],[<span class="hljs-number">-114.661844</span>,<span class="hljs-number">33.034958</span>],[<span class="hljs-number">-114.524921</span>,<span class="hljs-number">33.029481</span>],[<span class="hljs-number">-114.470151</span>,<span class="hljs-number">32.843265</span>],[<span class="hljs-number">-114.524921</span>,<span class="hljs-number">32.755634</span>],[<span class="hljs-number">-114.72209</span>,<span class="hljs-number">32.717295</span>],[<span class="hljs-number">-116.04751</span>,<span class="hljs-number">32.624187</span>],[<span class="hljs-number">-117.126467</span>,<span class="hljs-number">32.536556</span>],[<span class="hljs-number">-117.24696</span>,<span class="hljs-number">32.668003</span>],[<span class="hljs-number">-117.252437</span>,<span class="hljs-number">32.876127</span>],[<span class="hljs-number">-117.329114</span>,<span class="hljs-number">33.122589</span>],[<span class="hljs-number">-117.471515</span>,<span class="hljs-number">33.297851</span>],[<span class="hljs-number">-117.7837</span>,<span class="hljs-number">33.538836</span>],[<span class="hljs-number">-118.183517</span>,<span class="hljs-number">33.763391</span>],[<span class="hljs-number">-118.260194</span>,<span class="hljs-number">33.703145</span>],[<span class="hljs-number">-118.413548</span>,<span class="hljs-number">33.741483</span>],[<span class="hljs-number">-118.391641</span>,<span class="hljs-number">33.840068</span>],[<span class="hljs-number">-118.566903</span>,<span class="hljs-number">34.042715</span>],[<span class="hljs-number">-118.802411</span>,<span class="hljs-number">33.998899</span>],[<span class="hljs-number">-119.218659</span>,<span class="hljs-number">34.146777</span>],[<span class="hljs-number">-119.278905</span>,<span class="hljs-number">34.26727</span>],[<span class="hljs-number">-119.558229</span>,<span class="hljs-number">34.415147</span>],[<span class="hljs-number">-119.875891</span>,<span class="hljs-number">34.40967</span>],[<span class="hljs-number">-120.138784</span>,<span class="hljs-number">34.475393</span>],[<span class="hljs-number">-120.472878</span>,<span class="hljs-number">34.448009</span>],[<span class="hljs-number">-120.64814</span>,<span class="hljs-number">34.579455</span>],[<span class="hljs-number">-120.609801</span>,<span class="hljs-number">34.858779</span>],[<span class="hljs-number">-120.670048</span>,<span class="hljs-number">34.902595</span>],[<span class="hljs-number">-120.631709</span>,<span class="hljs-number">35.099764</span>],[<span class="hljs-number">-120.894602</span>,<span class="hljs-number">35.247642</span>],[<span class="hljs-number">-120.905556</span>,<span class="hljs-number">35.450289</span>],[<span class="hljs-number">-121.004141</span>,<span class="hljs-number">35.461243</span>],[<span class="hljs-number">-121.168449</span>,<span class="hljs-number">35.636505</span>],[<span class="hljs-number">-121.283465</span>,<span class="hljs-number">35.674843</span>],[<span class="hljs-number">-121.332757</span>,<span class="hljs-number">35.784382</span>],[<span class="hljs-number">-121.716143</span>,<span class="hljs-number">36.195153</span>],[<span class="hljs-number">-121.896882</span>,<span class="hljs-number">36.315645</span>],[<span class="hljs-number">-121.935221</span>,<span class="hljs-number">36.638785</span>],[<span class="hljs-number">-121.858544</span>,<span class="hljs-number">36.6114</span>],[<span class="hljs-number">-121.787344</span>,<span class="hljs-number">36.803093</span>],[<span class="hljs-number">-121.929744</span>,<span class="hljs-number">36.978355</span>],[<span class="hljs-number">-122.105006</span>,<span class="hljs-number">36.956447</span>],[<span class="hljs-number">-122.335038</span>,<span class="hljs-number">37.115279</span>],[<span class="hljs-number">-122.417192</span>,<span class="hljs-number">37.241248</span>],[<span class="hljs-number">-122.400761</span>,<span class="hljs-number">37.361741</span>],[<span class="hljs-number">-122.515777</span>,<span class="hljs-number">37.520572</span>],[<span class="hljs-number">-122.515777</span>,<span class="hljs-number">37.783465</span>],[<span class="hljs-number">-122.329561</span>,<span class="hljs-number">37.783465</span>],[<span class="hljs-number">-122.406238</span>,<span class="hljs-number">38.15042</span>],[<span class="hljs-number">-122.488392</span>,<span class="hljs-number">38.112082</span>],[<span class="hljs-number">-122.504823</span>,<span class="hljs-number">37.931343</span>],[<span class="hljs-number">-122.701993</span>,<span class="hljs-number">37.893004</span>],[<span class="hljs-number">-122.937501</span>,<span class="hljs-number">38.029928</span>],[<span class="hljs-number">-122.97584</span>,<span class="hljs-number">38.265436</span>],[<span class="hljs-number">-123.129194</span>,<span class="hljs-number">38.451652</span>],[<span class="hljs-number">-123.331841</span>,<span class="hljs-number">38.566668</span>],[<span class="hljs-number">-123.44138</span>,<span class="hljs-number">38.698114</span>],[<span class="hljs-number">-123.737134</span>,<span class="hljs-number">38.95553</span>],[<span class="hljs-number">-123.687842</span>,<span class="hljs-number">39.032208</span>],[<span class="hljs-number">-123.824765</span>,<span class="hljs-number">39.366301</span>],[<span class="hljs-number">-123.764519</span>,<span class="hljs-number">39.552517</span>],[<span class="hljs-number">-123.85215</span>,<span class="hljs-number">39.831841</span>],[<span class="hljs-number">-124.109566</span>,<span class="hljs-number">40.105688</span>],[<span class="hljs-number">-124.361506</span>,<span class="hljs-number">40.259042</span>],[<span class="hljs-number">-124.410798</span>,<span class="hljs-number">40.439781</span>],[<span class="hljs-number">-124.158859</span>,<span class="hljs-number">40.877937</span>],[<span class="hljs-number">-124.109566</span>,<span class="hljs-number">41.025814</span>],[<span class="hljs-number">-124.158859</span>,<span class="hljs-number">41.14083</span>],[<span class="hljs-number">-124.065751</span>,<span class="hljs-number">41.442061</span>],[<span class="hljs-number">-124.147905</span>,<span class="hljs-number">41.715908</span>],[<span class="hljs-number">-124.257444</span>,<span class="hljs-number">41.781632</span>],[<span class="hljs-number">-124.213628</span>,<span class="hljs-number">42.000709</span>],[<span class="hljs-number">-123.233256</span>,<span class="hljs-number">42.006186</span>]]]}};
 
-<span class="hljs-keyword">var</span> triangles = turf.tesselate(poly);
+<span class="hljs-keyword">var</span> triangles = turf.tesselate(polygon);
 
 <span class="hljs-comment">//=triangles</span></pre>
     

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "scripts": {
     "docs": "documentation build -c documentation.yml turf/packages/turf-*/index.js -f html -o docs",
-    "test": "documentation lint turf/packages/turf-*/index.js",
+    "lint": "documentation lint turf/packages/turf-*/index.js",
+    "build-test": "node test/build",
+    "test-runner": "ava test/turf.js",
+    "test": "npm run lint && npm run build-test && npm run test-runner",
     "serve": "documentation serve -c documentation.yml turf/packages/turf-*/index.js -f html -o docs"
   },
   "repository": {
@@ -24,11 +27,14 @@
   },
   "homepage": "https://github.com/turfjs/turf-www",
   "dependencies": {
+    "@turf/turf": "^3.7.4",
     "lodash": "^3.3.1",
-    "striptags": "^2.0.1",
-    "turf": "^3.0.0"
+    "striptags": "^2.0.1"
   },
   "devDependencies": {
-    "documentation": "4.0.0-beta8"
+    "@turf/meta": "^3.7.3",
+    "ava": "^0.17.0",
+    "documentation": "4.0.0-beta8",
+    "glob": "^7.1.1"
   }
 }

--- a/test/build.js
+++ b/test/build.js
@@ -18,7 +18,7 @@ glob('turf/packages/turf-*/index.js', function (err, files) {
     writeableStream.on('error', function (err) {
       throw err;
     });
-    turfFunctions.map(function (turfFunction) {
+    turfFunctions.forEach(function (turfFunction) {
       if(turfFunction.examples) {
         turfFunction.examples.forEach(function (example) {
           var turfName = turfFunction.name;
@@ -33,5 +33,6 @@ glob('turf/packages/turf-*/index.js', function (err, files) {
         });
       }
     });
+    writeableStream.end();
   });
 });

--- a/test/build.js
+++ b/test/build.js
@@ -1,0 +1,37 @@
+var documentation = require('documentation');
+var glob = require('glob');
+var fs = require('fs');
+var path = require('path');
+var testFilePath = path.resolve(__dirname + '/turf.js');
+
+var requireString = 'var turf = require(\'@turf/turf\');\n\nvar turfMeta = require(\'@turf/meta\');\n\nvar test = require(\'ava\');\n\n';
+glob('../turf/packages/turf-*/index.js', function (err, files) {
+  if (err) {
+    throw err;
+  }
+  documentation.build(files, {}, function (err, turfFunctions) {
+    if (err) {
+      throw err;
+    }
+    var writeableStream = fs.createWriteStream(testFilePath);
+    writeableStream.write(requireString);
+    writeableStream.on('error', function (err) {
+      throw err;
+    });
+    turfFunctions.map(function (turfFunction) {
+      if(turfFunction.examples) {
+        turfFunction.examples.forEach(function (example) {
+          var turfName = turfFunction.name;
+          var testFunctionName = turfName + 'Test';
+          writeableStream.write('\ntest(\'turf => ' + turfName + '\', function (t) {\n\n');
+          writeableStream.write('var ' + testFunctionName + ' = function ' + testFunctionName + '() {\n\n');
+          writeableStream.write(example.description);
+          writeableStream.write('\n\n}\n');
+          writeableStream.write(testFunctionName + '();\n\n');
+          writeableStream.write('\nt.pass();\n\n');
+          writeableStream.write('});\n\n');
+        });
+      }
+    });
+  });
+});

--- a/test/build.js
+++ b/test/build.js
@@ -5,7 +5,7 @@ var path = require('path');
 var testFilePath = path.resolve(__dirname + '/turf.js');
 
 var requireString = 'var turf = require(\'@turf/turf\');\n\nvar turfMeta = require(\'@turf/meta\');\n\nvar test = require(\'ava\');\n\n';
-glob('../turf/packages/turf-*/index.js', function (err, files) {
+glob('turf/packages/turf-*/index.js', function (err, files) {
   if (err) {
     throw err;
   }


### PR DESCRIPTION
@DenisCarriere, here is my implementation of what we discussed in #83. 

The following is my thought process for the changes made:
- the build-test script calls `documentation.build` generating documentation.js's JSON output.
- the json output is parsed to find each individual example
- the examples are written to a file wrapped in testing functions.
  - [AVA](https://github.com/avajs/ava) is used for testing. If you would like to see a different test runner, please let me know.
  - the test assertion is that the generated function from the example completes without error
  - all example tests are written to one file, but split into separate tests. I can split the individual tests into different files, if needed.
- the main test file requires @turf/turf as well as @turf/meta.
  - examples for turf functions would need to be referenced as turf.{function}
  - examples for turf meta functions would need to be referenced as turfMeta.{function}
  - the updates needed for all examples to pass tests are found here: https://github.com/jvrousseau/turf/tree/update-examples.
  - I have linked the turf submodule to the above branch if anyone wanted to pull down the and test the code (will need to revert prior to merging).

Hopefully this is what you had in mind for some automated testing. If there are any changes that you or anyone else would like to see, please let me know.