### PR TITLE
tweak 'guides' links

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -39,10 +39,10 @@
     <h3>Guides</h3>
     <ul>
       <li>
-        <a href='https://www.mapbox.com/guides/intro-to-turf/'>Intro To Turf</a>
+        <a href='https://www.mapbox.com/help/how-analysis-works/'>Spatial analysis - Intro To Turf</a>
       </li>
       <li>
-        <a href='https://www.mapbox.com/guides/analysis-with-turf/'>Analysis with Turf.js</a>
+        <a href='https://www.mapbox.com/help/analysis-with-turf/'>Analyze data with Turf.js</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Guess the guides were rearranged on mapbox.com. Fix the redirecting. Match link text with the title a bit more