### PR TITLE
bump node-sass to fix build issues on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "glob": "^7.1.2",
     "iview-loader": "^1.0.0",
     "load-json-file": "^4.0.0",
-    "node-sass": "^4.14.1",
+    "node-sass": "^8.0.0",
     "sass-loader": "^6.0.6",
     "shx": "^0.2.2",
     "write-json-file": "^2.3.0",


### PR DESCRIPTION
This PR bumps node-sass to the latest version. It fixes the current error I'm receiving on `npm run start`

`Module build failed: Error: Node Sass does not yet support your current environment: Linux 64-bit with Unsupported runtime (93)`