### PR TITLE
Add Node 16 to the GitHub actions build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        version: [14, 16]
     name: Build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Keeps in check that the project can build with Node 16. In the future we can add Node 18 when we are comfortable this will work.