### PR TITLE
Adding Algolia search config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,12 @@ const config = {
 
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
+    {
+      algolia: {
+        appId: "7K3RMBBM3L",
+        apiKey: "9980d437c715b44d59f74141fa0a0161",
+        indexName: "turfjs",
+      },
       // Replace with your project's social card
       image: "img/docusaurus-social-card.jpg",
       navbar: {
@@ -149,7 +154,7 @@ const config = {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
       },
-    }),
+    },
 };
 
 export default config;


### PR DESCRIPTION
Registered Turf for the free docusaurus search provided by Algolia. Site is already indexed. Adding config should provide out of the box support.