### PR TITLE
Updated mapbox access token in *both* places this time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,6 +36,11 @@ const config = {
     locales: ["en"],
   },
 
+  customFields: {
+    mapboxAccessToken:
+      "pk.eyJ1IjoidHVyZmpzIiwiYSI6ImNtYWRsY2p4MzBoNDAyd29sdTZ3anM4cTYifQ.geW7aD3o2GBOKoub_wzwnQ",
+  },
+
   presets: [
     [
       "classic",

--- a/src/components/ExampleMap/index.js
+++ b/src/components/ExampleMap/index.js
@@ -1,9 +1,11 @@
 import React, { useEffect } from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 export default function ExampleMap(props) {
+  const { siteConfig } = useDocusaurusContext();
+
   useEffect(() => {
-    L.mapbox.accessToken =
-      "pk.eyJ1IjoidHVyZmpzIiwiYSI6ImNtYWRsY2p4MzBoNDAyd29sdTZ3anM4cTYifQ.geW7aD3o2GBOKoub_wzwnQ";
+    L.mapbox.accessToken = siteConfig.customFields.mapboxAccessToken;
 
     // Remove any old map that might have been initialised.
     // https://github.com/Leaflet/Leaflet/issues/3962#issuecomment-500680902

--- a/src/components/HomepageMap/index.js
+++ b/src/components/HomepageMap/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import * as turf from "@turf/turf";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 function pointToLayer(feature, latlng) {
   return L.circleMarker(latlng, {
@@ -39,6 +40,8 @@ const geojsonOptions = {
 export default function HomepageMap(props) {
   const { turfFunction } = props;
 
+  const { siteConfig } = useDocusaurusContext();
+
   const points = turf.featureCollection([
     turf.point([-74.0, 40.739], { price: 8 }),
     turf.point([-73.992, 40.742], { price: 12 }),
@@ -77,8 +80,7 @@ export default function HomepageMap(props) {
   const addToMap = { points, features };
 
   useEffect(() => {
-    L.mapbox.accessToken =
-      "pk.eyJ1IjoidHVyZmpzIiwiYSI6ImNrZWp2ODRvNzFqMHoyeHJ6b3Jpc29iczQifQ.YdYb6a6rA5aCtkmDZ5wn_g";
+    L.mapbox.accessToken = siteConfig.customFields.mapboxAccessToken;
 
     // Remove any old map that might have been initialised.
     // https://github.com/Leaflet/Leaflet/issues/3962#issuecomment-500680902


### PR DESCRIPTION
Missed a reference to the mapbox token we were trying to replace so externalised it to site config for ease of updating.