### PR TITLE
Point "Edit this page" links to correct file in GitHub repository.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,15 +50,13 @@ const config = {
           sidebarPath: "./sidebars.js",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+          editUrl: "https://github.com/Turfjs/turf-www/tree/master/",
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+          editUrl: "https://github.com/Turfjs/turf-www/tree/master/",
         },
         theme: {
           customCss: "./src/css/custom.css",


### PR DESCRIPTION
Fixes https://github.com/Turfjs/turf-www/issues/216

Update Docusaurus config to point at turf-www repository.

Link screenshot from local env:
<img width="646" height="110" alt="Screenshot 2026-07-28 at 16 19 26" src="https://github.com/user-attachments/assets/9eb221ff-bed8-4a1b-b01c-80dfea913a64" />
