### PR TITLE
Small fixes necessary to do updates for new Turf releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "generate-api-mdx": "npx tsx ./scripts/generate-api-mdx.ts"
+    "generate-api-mdx": "pnpx tsx ./scripts/generate-api-mdx.ts"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.2",

--- a/scripts/generate-api-mdx.ts
+++ b/scripts/generate-api-mdx.ts
@@ -10,7 +10,7 @@ import * as prettier from "prettier";
   // in an IIFE as top level async not allowed.
   const documentation = await import("documentation");
 
-  const srcPathDir = path.resolve("/Users/james/Code/turf/span");
+  const srcPathDir = path.resolve(__dirname, "../turf");
   const docsOutDir = path.resolve(__dirname, "..", "docs");
 
   interface SidebarConfig {


### PR DESCRIPTION
- Use pnpx instead of npx to make sure we don't get an error about using the wrong package manager
- Fix srcPathDir to be configuration independant